### PR TITLE
Update Makefile get repo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT := $(shell git log -1 --format='%H')
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell git describe --tags)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
Update `Makefile` to get the current repo tags for `fairyringd` version instead of using the branch & commit as version.