### PR TITLE
Fix/remove no aggr key encrypted txs

### DIFF
--- a/x/pep/module.go
+++ b/x/pep/module.go
@@ -274,7 +274,14 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 
 		key, found := am.keeper.GetAggregatedKeyShare(ctx, h)
 		if !found {
-			am.keeper.Logger(ctx).Error(fmt.Sprintf("Decryption key not found for block height: %d", h))
+			am.keeper.Logger(ctx).Error(fmt.Sprintf("Decryption key not found for block height: %d, Removing all the encrypted txs...", h))
+			encryptedTxs := am.keeper.GetEncryptedTxAllFromHeight(ctx, h)
+			if len(encryptedTxs.EncryptedTx) > 0 {
+				am.keeper.RemoveAllEncryptedTxFromHeight(ctx, h)
+				am.keeper.Logger(ctx).Info(fmt.Sprintf("Removed total %d encrypted txs at block %d", len(encryptedTxs.EncryptedTx), h))
+			} else {
+				am.keeper.Logger(ctx).Info(fmt.Sprintf("No encrypted tx found at block %d", h))
+			}
 			continue
 		}
 

--- a/x/pep/module.go
+++ b/x/pep/module.go
@@ -279,6 +279,16 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 			if len(encryptedTxs.EncryptedTx) > 0 {
 				am.keeper.RemoveAllEncryptedTxFromHeight(ctx, h)
 				am.keeper.Logger(ctx).Info(fmt.Sprintf("Removed total %d encrypted txs at block %d", len(encryptedTxs.EncryptedTx), h))
+				indexes := make([]string, len(encryptedTxs.EncryptedTx))
+				for _, v := range encryptedTxs.EncryptedTx {
+					indexes = append(indexes, strconv.FormatUint(v.Index, 10))
+				}
+				ctx.EventManager().EmitEvent(
+					sdk.NewEvent(types.EncryptedTxDiscardedEventType,
+						sdk.NewAttribute(types.EncryptedTxDiscardedEventTxIDs, strings.Join(indexes, ",")),
+						sdk.NewAttribute(types.EncryptedTxDiscardedEventHeight, strconv.FormatUint(h, 10)),
+					),
+				)
 			} else {
 				am.keeper.Logger(ctx).Info(fmt.Sprintf("No encrypted tx found at block %d", h))
 			}

--- a/x/pep/types/keys.go
+++ b/x/pep/types/keys.go
@@ -56,6 +56,12 @@ const (
 )
 
 const (
+	EncryptedTxDiscardedEventType   = "discarded-encrypted-tx"
+	EncryptedTxDiscardedEventHeight = "discarded-height"
+	EncryptedTxDiscardedEventTxIDs  = "discarded-tx-ids"
+)
+
+const (
 	KeyShareVerificationType    = "keyshare-verification"
 	KeyShareVerificationCreator = "keyshare-verification-creator"
 	KeyShareVerificationHeight  = "keyshare-verification-height"


### PR DESCRIPTION
- Add remove encrypted txs in previous blocks that has no aggregated key 
- Add emit event with all the removed txs id & height after removing it