### PR TITLE
fix app_config.go

### DIFF
--- a/app/app_config.go
+++ b/app/app_config.go
@@ -250,7 +250,7 @@ var (
 				Name: stakingtypes.ModuleName,
 				Config: appconfig.WrapAny(&stakingmodulev1.Module{
 					// NOTE: specifying a prefix is only necessary when using bech32 addresses
-					// If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
+					// If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
 					Bech32PrefixValidator: AccountAddressPrefix + "valoper",
 					Bech32PrefixConsensus: AccountAddressPrefix + "valcons",
 				}),


### PR DESCRIPTION
Before: // If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
After: // If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default