### PR TITLE
Fix typo README.md

### DIFF
--- a/abci/README.md
+++ b/abci/README.md
@@ -139,7 +139,7 @@ If any of the lanes fail during `ProcessLane`, the entire proposal is rejected. 
 
 ### Proposal Verification Example
 
-Following the example above, let's say we recieve the same proposal from the network:
+Following the example above, let's say we receive the same proposal from the network:
 
 ```golang
 blockProposal := {


### PR DESCRIPTION
## Pull Request Title: Fix Typo in `README.md`

### Description:
This pull request corrects a typo in the `README.md` file under the `Proposal Verification Example` section. The word "recieve" was corrected to "receive."

### Changes Made:
- Fixed the typo in the following sentence:
  - **Original:** "Following the example above, let's say we recieve the same proposal from the network:"
  - **Corrected:** "Following the example above, let's say we receive the same proposal from the network:"

### Reason for the Change:
- The change ensures the documentation is free of spelling errors, improving its clarity and professionalism.

### Testing:
- This is a documentation-only change and does not impact code functionality. No testing is required.

### Additional Notes:
- This is a minor, non-breaking improvement.
- Please let me know if any additional edits or modifications are needed!

---

Let me know if you'd like me to adjust this template further!
