### PR TITLE
Typo fix msg_send_keyshare.go

### DIFF
--- a/x/keyshare/keeper/msg_send_keyshare.go
+++ b/x/keyshare/keeper/msg_send_keyshare.go
@@ -20,7 +20,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// SendKeyshare registers a new keyshare submited by a validator for a particular height
+// SendKeyshare registers a new keyshare submitted by a validator for a particular height
 
 func (k msgServer) SendKeyshare(goCtx context.Context, msg *types.MsgSendKeyshare) (*types.MsgSendKeyshareResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)


### PR DESCRIPTION
# **Typo Fix in `msg_send_keyshare.go`**

## **Description**
This pull request fixes a typo in the `msg_send_keyshare.go` file. The typo was corrected to ensure proper spelling and maintain the consistency of the codebase.

## **Changes**
- Corrected a typo in the file to improve clarity and readability.

## **Impact**
- This is a minor fix with no changes to the functionality of the code.

## **Testing**
- No testing required, as this is a simple typo fix.
